### PR TITLE
[BUG] 修复: 将书籍标签作为DC.subject元数据添加到EPUB，而不是加入到出版社

### DIFF
--- a/novel_src/book_parser/epub_generator.py
+++ b/novel_src/book_parser/epub_generator.py
@@ -14,6 +14,7 @@ class EpubGenerator:
         author=None,
         description=None,
         publisher=None,
+        tags=None,
     ):
         """
         初始化EPUB书籍对象
@@ -21,7 +22,9 @@ class EpubGenerator:
         :param title: 书籍标题
         :param language: 语言代码（默认'en'）
         :param author: 作者（可选）
+        :param description: 书籍描述（可选）
         :param publisher: 出版社（可选）
+        :param tags: 书籍标签列表或字符串（可选）
         """
         self.book = epub.EpubBook()
 
@@ -73,6 +76,20 @@ class EpubGenerator:
             self.book.add_metadata("DC", "publisher", publisher)
         if description:
             self.book.add_metadata("DC", "description", description)
+        
+        # 添加标签到DC.subject元数据
+        if tags:
+            # 处理标签格式：如果是字符串则分割，否则直接使用列表
+            if isinstance(tags, str):
+                tag_list = [t.strip() for t in tags.split("|") if t.strip()]
+            elif isinstance(tags, list):
+                tag_list = [str(t).strip() for t in tags if str(t).strip()]
+            else:
+                tag_list = []
+            
+            # 为每个标签添加DC.subject元数据
+            for tag in tag_list:
+                self.book.add_metadata("DC", "subject", tag)
 
         self.chapters = []
         self._file_counter = 0  # 用于生成自动文件名

--- a/novel_src/book_parser/finalize_utils.py
+++ b/novel_src/book_parser/finalize_utils.py
@@ -69,9 +69,7 @@ def _finalize_txt(manager, chapters: list[dict], output_file: Path):
 
 # -------- EPUB 主流程 --------
 def _finalize_epub(manager, chapters: list[dict], output_file: Path):
-    publisher = None
-    if isinstance(manager.tags, str) and manager.tags.strip():
-        publisher = ", ".join([t for t in manager.tags.split("|") if t])
+    publisher = None  # 不使用标签作为出版社，保持为空或使用默认值
     epub = EpubGenerator(
         manager.book_id or manager.book_name or "id",
         manager.book_name or "",
@@ -79,6 +77,7 @@ def _finalize_epub(manager, chapters: list[dict], output_file: Path):
         manager.author or None,
         manager.description or None,
         publisher,
+        manager.tags,  # 将标签传递给EPUB生成器，添加到DC.subject元数据
     )
     # 早期兜底：如果没有任何可用章节（例如用户中断在早期），也生成一个仅包含“介绍页”的最小 EPUB，避免 Document is empty
     safe_minimal_mode = False


### PR DESCRIPTION
## 分类

- [x] BUG 修复（bug）
- [ ] 新功能（enhancement）
- [ ] 文档（documentation）
- [ ] 更新/优化（update）

## 变更内容概述
修改EPUB生成器以接收标签参数，并将标签添加到DC.subject元数据中。不再使用标签作为出版社信息，保持出版社字段为空或使用默认值。

## 日志（如为问题修复/行为变更，请附最新一次 logs/latest.log 或压缩包）
因为某些原因无法提供

## 兼容性/风险评估

- [ ] 无破坏性变更
- [ ] 需要文档更新
- [ ] 配置/环境有变更
